### PR TITLE
Feature: Add Rack::JWT

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in logicware.gemspec
 gemspec
-
-gem "rake", "~> 13.0"
-gem "rspec", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,30 @@ PATH
   remote: .
   specs:
     logicware (0.1.0)
+      jwt (~> 2.2.0)
+      rack
 
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.1.1)
+    coderay (1.1.2)
     diff-lcs (1.3)
+    ffi (1.12.2)
+    jwt (2.2.1)
+    method_source (1.0.0)
+    pry (0.13.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    rack (2.2.2)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
     rake (13.0.1)
+    rbnacl (7.1.1)
+      ffi
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -26,9 +44,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bundler (>= 2.1.0)
   logicware!
-  rake (~> 13.0)
-  rspec (~> 3.0)
+  pry-byebug
+  rack-test (>= 1.1.0)
+  rake (>= 13.0.0)
+  rbnacl (>= 7.0.0)
+  rspec (>= 3.9.0)
 
 BUNDLED WITH
    2.1.4

--- a/lib/logicware.rb
+++ b/lib/logicware.rb
@@ -2,5 +2,6 @@ require "logicware/version"
 
 module Logicware
   class Error < StandardError; end
-  # Your code goes here...
+
+  autoload :JWT, 'logicware/rack/jwt'
 end

--- a/lib/logicware/rack/jwt.rb
+++ b/lib/logicware/rack/jwt.rb
@@ -1,0 +1,9 @@
+module Logicware
+  module Rack
+    # JSON Web Token
+    module JWT
+      autoload :Auth, 'logicware/rack/jwt/auth'
+      autoload :Token, 'logicware/rack/jwt/token'
+    end
+  end
+end

--- a/lib/logicware/rack/jwt/auth.rb
+++ b/lib/logicware/rack/jwt/auth.rb
@@ -1,0 +1,218 @@
+require 'jwt'
+
+module Logicware
+  module Rack
+    module JWT
+      # Authentication middleware
+      class Auth
+        attr_reader :secret
+        attr_reader :verify
+        attr_reader :options
+        attr_reader :exclude
+  
+        SUPPORTED_ALGORITHMS = [
+          'none',
+          'HS256',
+          'HS384',
+          'HS512',
+          'RS256',
+          'RS384',
+          'RS512',
+          'ES256',
+          'ES384',
+          'ES512',
+          ('ED25519' if defined?(RbNaCl)),
+        ].compact.freeze
+  
+        DEFAULT_ALGORITHM = 'HS256'.freeze
+  
+        # The last segment gets dropped for 'none' algorithm since there is no
+        # signature so both of these patterns are valid. All character chunks
+        # are base64url format and periods.
+        #   Bearer abc123.abc123.abc123
+        #   Bearer abc123.abc123.
+        BEARER_TOKEN_REGEX = %r{
+          ^Bearer\s{1}(       # starts with Bearer and a single space
+          [a-zA-Z0-9\-\_]+\.  # 1 or more chars followed by a single period
+          [a-zA-Z0-9\-\_]+\.  # 1 or more chars followed by a single period
+          [a-zA-Z0-9\-\_]*    # 0 or more chars, no trailing chars
+          )$
+        }x
+  
+        JWT_DECODE_ERRORS = [
+          ::JWT::DecodeError,
+          ::JWT::VerificationError,
+          ::JWT::ExpiredSignature,
+          ::JWT::IncorrectAlgorithm,
+          ::JWT::ImmatureSignature,
+          ::JWT::InvalidIssuerError,
+          ::JWT::InvalidIatError,
+          ::JWT::InvalidAudError,
+          ::JWT::InvalidSubError,
+          ::JWT::InvalidJtiError,
+          ::JWT::InvalidPayload,
+        ].freeze
+  
+        MissingAuthHeader = Class.new(StandardError)
+        InvalidAuthHeaderFormat = Class.new(StandardError)
+  
+        ERRORS_TO_RESCUE = (JWT_DECODE_ERRORS + [MissingAuthHeader, InvalidAuthHeaderFormat]).freeze
+  
+        # Initialization should fail fast with an ArgumentError
+        # if any args are invalid.
+        def initialize(app, opts = {})
+          @app     = app
+          @secret  = opts.fetch(:secret, nil)
+          @verify  = opts.fetch(:verify, true)
+          @options = opts.fetch(:options, {})
+          @exclude = opts.fetch(:exclude, [])
+  
+          @on_error = opts.fetch(:on_error, method(:default_on_error))
+  
+          @secret = @secret.strip if @secret.is_a?(String)
+          @options[:algorithm] = DEFAULT_ALGORITHM if @options[:algorithm].nil?
+  
+          check_secret_type!
+          check_secret!
+          check_secret_and_verify_for_none_alg!
+          check_verify_type!
+          check_options_type!
+          check_valid_algorithm!
+          check_exclude_type!
+          check_on_error_callable!
+        end
+  
+        def call(env)
+          if path_matches_excluded_path?(env)
+            @app.call(env)
+          else
+            verify_token(env)
+          end
+        end
+  
+        private
+  
+        def verify_token(env)
+          raise MissingAuthHeader if missing_auth_header?(env)
+          raise InvalidAuthHeaderFormat if invalid_auth_header?(env)
+  
+          # extract the token from the Authorization: Bearer header
+          # with a regex capture group.
+          token = BEARER_TOKEN_REGEX.match(env['HTTP_AUTHORIZATION'])[1]
+  
+          decoded_token = Token.decode(token, @secret, @verify, @options)
+          env['jwt.payload'] = decoded_token.first
+          env['jwt.header'] = decoded_token.last
+          @app.call(env)
+        rescue *ERRORS_TO_RESCUE => e
+          @on_error.call(e)
+        end
+  
+        def check_secret_type!
+          unless Token.secret_of_valid_type?(@secret)
+            raise ArgumentError, 'secret argument must be a valid type'
+          end
+        end
+  
+        def check_secret!
+          if @secret.nil? || (@secret.is_a?(String) && @secret.empty?)
+            unless @options[:algorithm] == 'none'
+              raise ArgumentError, 'secret argument can only be nil/empty for the "none" algorithm'
+            end
+          end
+        end
+  
+        def check_secret_and_verify_for_none_alg!
+          if @options && @options[:algorithm] && @options[:algorithm] == 'none'
+            unless @secret.nil? && @verify.is_a?(FalseClass)
+              raise ArgumentError, 'when "none" the secret must be "nil" and verify "false"'
+            end
+          end
+        end
+  
+        def check_verify_type!
+          unless verify.is_a?(TrueClass) || verify.is_a?(FalseClass)
+            raise ArgumentError, 'verify argument must be true or false'
+          end
+        end
+  
+        def check_options_type!
+          raise ArgumentError, 'options argument must be a Hash' unless options.is_a?(Hash)
+        end
+  
+        def check_valid_algorithm!
+          unless @options &&
+                 @options[:algorithm] &&
+                 SUPPORTED_ALGORITHMS.include?(@options[:algorithm])
+            raise ArgumentError, 'algorithm argument must be a supported type'
+          end
+        end
+  
+        def check_exclude_type!
+          unless @exclude.is_a?(Array)
+            raise ArgumentError, 'exclude argument must be an Array'
+          end
+  
+          @exclude.each do |x|
+            unless x.is_a?(String)
+              raise ArgumentError, 'each exclude Array element must be a String'
+            end
+  
+            if x.empty?
+              raise ArgumentError, 'each exclude Array element must not be empty'
+            end
+  
+            unless x.start_with?('/')
+              raise ArgumentError, 'each exclude Array element must start with a /'
+            end
+          end
+        end
+  
+        def check_on_error_callable!
+          unless @on_error.respond_to?(:call)
+            raise ArgumentError, 'on_error argument must respond to call'
+          end
+        end
+  
+        def path_matches_excluded_path?(env)
+          @exclude.any? { |ex| env['PATH_INFO'].start_with?(ex) }
+        end
+  
+        def valid_auth_header?(env)
+          env['HTTP_AUTHORIZATION'] =~ BEARER_TOKEN_REGEX
+        end
+  
+        def invalid_auth_header?(env)
+          !valid_auth_header?(env)
+        end
+  
+        def missing_auth_header?(env)
+          env['HTTP_AUTHORIZATION'].nil? || env['HTTP_AUTHORIZATION'].strip.empty?
+        end
+  
+        def default_on_error(error)
+          error_message = {
+            ::JWT::DecodeError => 'Invalid JWT token : Decode Error',
+            ::JWT::VerificationError => 'Invalid JWT token : Signature Verification Error',
+            ::JWT::ExpiredSignature => 'Invalid JWT token : Expired Signature (exp)',
+            ::JWT::IncorrectAlgorithm => 'Invalid JWT token : Incorrect Key Algorithm',
+            ::JWT::ImmatureSignature => 'Invalid JWT token : Immature Signature (nbf)',
+            ::JWT::InvalidIssuerError => 'Invalid JWT token : Invalid Issuer (iss)',
+            ::JWT::InvalidIatError => 'Invalid JWT token : Invalid Issued At (iat)',
+            ::JWT::InvalidAudError => 'Invalid JWT token : Invalid Audience (aud)',
+            ::JWT::InvalidSubError => 'Invalid JWT token : Invalid Subject (sub)',
+            ::JWT::InvalidJtiError => 'Invalid JWT token : Invalid JWT ID (jti)',
+            ::JWT::InvalidPayload => 'Invalid JWT token : Invalid Payload',
+            MissingAuthHeader => 'Missing Authorization header',
+            InvalidAuthHeaderFormat => 'Invalid Authorization header format'
+          }
+          message = error_message.fetch(error.class, 'Default')
+          body    = { error: message }.to_json
+          headers = { 'Content-Type' => 'application/json', 'Content-Length' => body.bytesize.to_s }
+  
+          [401, headers, [body]]
+        end
+      end
+    end
+  end
+end

--- a/lib/logicware/rack/jwt/token.rb
+++ b/lib/logicware/rack/jwt/token.rb
@@ -1,0 +1,71 @@
+module Logicware
+  module Rack
+    module JWT
+      # Token encoding and decoding
+      class Token
+        # abc123.abc123.abc123    (w/ signature)
+        # abc123.abc123.          ('none')
+        TOKEN_REGEX = /\A([a-zA-Z0-9\-\_\~\+\\]+\.[a-zA-Z0-9\-\_\~\+\\]+\.[a-zA-Z0-9\-\_\~\+\\]*)\z/
+        DEFAULT_HEADERS = {typ: 'JWT'}
+
+        def self.encode(payload, secret, alg = 'HS256')
+          raise 'Invalid payload. Must be a Hash.' unless payload.is_a?(Hash)
+          raise 'Invalid secret type.'             unless secret_of_valid_type?(secret)
+          raise 'Unsupported algorithm'            unless algorithm_supported?(alg)
+
+          # if using an unsigned token ('none' alg) you *must* set the `secret`
+          # to `nil` in which case any user provided `secret` will be ignored.
+          if alg == 'none'
+            ::JWT.encode(payload, nil, alg, DEFAULT_HEADERS)
+          else
+            ::JWT.encode(payload, secret, alg, DEFAULT_HEADERS)
+          end
+        end
+
+        def self.decode(token, secret, verify, options = {})
+          raise 'Invalid token format.'     unless valid_token_format?(token)
+          raise 'Invalid secret type.'      unless secret_of_valid_type?(secret)
+          raise 'Unsupported verify value.' unless verify_of_valid_type?(verify)
+          options[:algorithm] = 'HS256'     if options[:algorithm].nil?
+          raise 'Unsupported algorithm'     unless algorithm_supported?(options[:algorithm])
+
+          # If using an unsigned 'none' algorithm token you *must* set the
+          # `secret` to `nil` and `verify` to `false` or it won't work per
+          # the ruby-jwt docs. Using 'none' is probably not recommended.
+          if options[:algorithm] == 'none'
+            ::JWT.decode(token, nil, false, options)
+          else
+            ::JWT.decode(token, secret, verify, options)
+          end
+        end
+
+        def self.secret_of_valid_type?(secret)
+          secret.nil? ||
+            secret.is_a?(String) ||
+            secret.is_a?(OpenSSL::PKey::RSA) ||
+            secret.is_a?(OpenSSL::PKey::EC)  ||
+            (defined?(RbNaCl) && secret.is_a?(RbNaCl::Signatures::Ed25519::SigningKey)) ||
+            (defined?(RbNaCl) && secret.is_a?(RbNaCl::Signatures::Ed25519::VerifyKey))
+        end
+
+        # Private Utility Class Methods
+        # See : https://gist.github.com/Integralist/bb8760d11a03c88da151
+
+        def self.valid_token_format?(token)
+          token =~ TOKEN_REGEX
+        end
+        private_class_method :valid_token_format?
+
+        def self.algorithm_supported?(alg)
+          Logicware::Rack::JWT::Auth::SUPPORTED_ALGORITHMS.include?(alg)
+        end
+        private_class_method :algorithm_supported?
+
+        def self.verify_of_valid_type?(verify)
+          verify.nil? || verify.is_a?(FalseClass) || verify.is_a?(TrueClass)
+        end
+        private_class_method :verify_of_valid_type?
+      end
+    end
+  end
+end

--- a/logicware.gemspec
+++ b/logicware.gemspec
@@ -11,6 +11,17 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://www.openware.com/"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
+
+  spec.add_development_dependency 'bundler',   '>= 2.1.0'
+  spec.add_development_dependency 'rake',      '>= 13.0.0'
+  spec.add_development_dependency 'rack-test', '>= 1.1.0'
+  spec.add_development_dependency 'rspec',     '>= 3.9.0'
+  spec.add_development_dependency 'rbnacl',    '>= 7.0.0'
+  spec.add_development_dependency "pry-byebug"
+
+  spec.add_runtime_dependency 'rack'
+  spec.add_runtime_dependency 'jwt',  '~> 2.2.0'
+
   spec.metadata["allowed_push_host"] = "http://mygemserver.com"
 
   spec.metadata["homepage_uri"] = spec.homepage

--- a/spec/jwt/auth_spec.rb
+++ b/spec/jwt/auth_spec.rb
@@ -1,0 +1,158 @@
+describe Logicware::Rack::JWT::Auth do
+  let(:issuer)  { Logicware::Rack::JWT::Token }
+  let(:secret)  { 'secret' } # use 'secret to match hardcoded 'secret' @ http://jwt.io'
+  let(:verify)  { true }
+  let(:payload) { { foo: 'bar' } }
+
+  let(:inner_app) do
+    ->(env) { [200, env, [payload.to_json]] }
+  end
+
+  let(:app) do
+    Logicware::Rack::JWT::Auth.new(inner_app, secret: secret)
+  end
+
+  describe 'initialization of' do
+    describe 'secret' do
+      describe 'with only secret: arg provided' do
+        let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret) }
+        it 'succeeds' do
+          expect(app.secret).to eq(secret)
+        end
+      end
+
+      describe 'with no secret: arg provided' do
+        it 'raises ArgumentError' do
+          expect { Logicware::Rack::JWT::Auth.new(inner_app, {}) }.to raise_error(ArgumentError)
+        end
+      end
+
+      describe 'with secret: arg of invalid type' do
+        it 'raises ArgumentError' do
+          expect { Logicware::Rack::JWT::Auth.new(inner_app, secret: []) }.to raise_error(ArgumentError)
+        end
+      end
+
+      describe 'with nil secret: arg provided' do
+        it 'raises ArgumentError' do
+          expect { Logicware::Rack::JWT::Auth.new(inner_app, secret: nil) }.to raise_error(ArgumentError)
+        end
+      end
+
+      describe 'with empty secret: arg provided' do
+        it 'raises ArgumentError' do
+          expect { Logicware::Rack::JWT::Auth.new(inner_app, secret: '') }.to raise_error(ArgumentError)
+        end
+      end
+
+      describe 'with spaces secret: arg provided' do
+        it 'raises ArgumentError' do
+          expect { Logicware::Rack::JWT::Auth.new(inner_app, secret: '     ') }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    describe 'verify' do
+      describe 'with true arg' do
+        let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, verify: true) }
+
+        it 'succeeds' do
+          header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS256')}"
+          get('/')
+          expect(last_response.status).to eq 200
+        end
+      end
+
+      describe 'with false arg' do
+        let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, verify: false) }
+
+        it 'succeeds' do
+          header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS256')}"
+          get('/')
+          expect(last_response.status).to eq 200
+        end
+      end
+
+      describe 'with a bad arg' do
+        it 'raises ArgumentError' do
+          expect { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, verify: "badStringArg") }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    describe 'options' do
+      describe 'when algorithm "none" and secret is nil and verify is false' do
+        let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: nil, verify: false, options: { algorithm: 'none' }) }
+
+        it 'succeeds' do
+          header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS256')}"
+          get('/')
+          expect(last_response.status).to eq 200
+        end
+      end
+
+      describe 'when algorithm "none" and secret not nil but verify is false' do
+        it 'raises an exception' do
+          args = { secret: secret, verify: false, options: { algorithm: 'none' } }
+          expect { Logicware::Rack::JWT::Auth.new(inner_app, args) }.to raise_error(ArgumentError)
+        end
+      end
+
+      describe 'when algorithm "none" and secret is nil but verify not false' do
+        it 'raises an exception' do
+          args = { secret: nil, verify: true, options: { algorithm: 'none' } }
+          expect { Logicware::Rack::JWT::Auth.new(inner_app, args) }.to raise_error(ArgumentError)
+        end
+      end
+
+      describe 'when invalid algorithm provided' do
+        it 'raises an exception' do
+          args = { secret: secret, verify: true, options: { algorithm: 'badalg' } }
+          expect { Logicware::Rack::JWT::Auth.new(inner_app, args) }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    # see also exclusion_spec.rb
+    describe 'exclude' do
+      describe 'when a type other than Array provided' do
+        it 'raises an exception' do
+          args = { secret: secret, exclude: {} }
+          expect { Logicware::Rack::JWT::Auth.new(inner_app, args) }.to raise_error(ArgumentError)
+        end
+      end
+
+      describe 'when Array contains non-String elements' do
+        it 'raises an exception' do
+          args = { secret: secret, exclude: ['/foo', nil, '/bar'] }
+          expect { Logicware::Rack::JWT::Auth.new(inner_app, args) }.to raise_error(ArgumentError)
+        end
+      end
+
+      describe 'when Array contains empty String elements' do
+        it 'raises an exception' do
+          args = { secret: secret, exclude: ['/foo', '', '/bar'] }
+          expect { Logicware::Rack::JWT::Auth.new(inner_app, args) }.to raise_error(ArgumentError)
+        end
+      end
+
+      describe 'when Array contains elements that do not start with a /' do
+        it 'raises an exception' do
+          args = { secret: secret, exclude: ['/foo', 'bar', '/baz'] }
+          expect { Logicware::Rack::JWT::Auth.new(inner_app, args) }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    describe 'on_error' do
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret) }
+
+      describe 'when non-callable type provided' do
+        it 'raises an exception' do
+          args = { secret: secret, on_error: [] }
+          expect { Logicware::Rack::JWT::Auth.new(inner_app, args) }.to raise_error(ArgumentError)
+        end
+      end
+    end
+  end
+end

--- a/spec/jwt/claims_spec.rb
+++ b/spec/jwt/claims_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+describe Logicware::Rack::JWT::Auth do
+  let(:issuer)  { Logicware::Rack::JWT::Token }
+  let(:secret)  { 'secret' } # use 'secret to match hardcoded 'secret' @ http://jwt.io'
+  let(:verify)  { true }
+  let(:payload) { { foo: 'bar' } }
+
+  let(:inner_app) do
+    ->(env) { [200, env, [payload.to_json]] }
+  end
+
+  let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret) }
+
+  describe 'passing throught a claim of type' do
+    # TODO : Add another block like this 'iat' block for each of the other claim types?
+
+    describe 'iat' do
+      describe 'will succeed' do
+        describe 'with a valid iat and verify_iat unset' do
+          let(:payload) { { data: 'foo', iat: Time.now.to_i } }
+          let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, verify: verify) }
+
+          it 'will succeed' do
+            header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS256')}"
+            get('/')
+            expect(last_response.status).to eq 200
+            body = JSON.parse(last_response.body, symbolize_names: true)
+            expect(body).to eq(payload)
+          end
+        end
+
+        describe 'with an invalid iat and verify_iat unset' do
+          let(:payload) { { data: 'foo', iat: Time.now.to_i + 1_000_000 } }
+          let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, verify: verify) }
+
+          it 'will succeed' do
+            header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS256')}"
+            get('/')
+            expect(last_response.status).to eq 200
+            body = JSON.parse(last_response.body, symbolize_names: true)
+            expect(body).to eq(payload)
+          end
+        end
+
+        describe 'with a valid iat and verify_iat: false' do
+          let(:payload) { { data: 'foo', iat: Time.now.to_i } }
+          let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, verify: verify, options: { verify_iat: false }) }
+
+          it 'will succeed' do
+            header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS256')}"
+            get('/')
+            expect(last_response.status).to eq 200
+            body = JSON.parse(last_response.body, symbolize_names: true)
+            expect(body).to eq(payload)
+          end
+        end
+
+        describe 'with a valid iat and verify_iat: true' do
+          let(:payload) { { data: 'foo', iat: Time.now.to_i } }
+          let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, verify: verify, options: { verify_iat: true }) }
+
+          it 'will succeed' do
+            header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS256')}"
+            get('/')
+            expect(last_response.status).to eq 200
+            body = JSON.parse(last_response.body, symbolize_names: true)
+            expect(body).to eq(payload)
+          end
+        end
+      end
+
+      describe 'will fail' do
+        describe 'with an invalid iat and verify_iat true' do
+          let(:payload) { { data: 'foo', iat: Time.now.to_i + 1_000_000 } }
+          let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, verify: verify, options: { verify_iat: true }) }
+
+          it 'will succeed' do
+            header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS256')}"
+            get('/')
+            expect(last_response.status).to eq 401
+            body = JSON.parse(last_response.body, symbolize_names: true)
+            expect(body).to eq({:error=>"Invalid JWT token : Invalid Issued At (iat)"})
+          end
+        end
+      end
+    end # iat
+
+  end
+end

--- a/spec/jwt/example_spec.rb
+++ b/spec/jwt/example_spec.rb
@@ -1,0 +1,69 @@
+describe 'README examples' do
+  let(:issuer)  { Logicware::Rack::JWT::Token }
+  let(:secret)  { 'secret' } # use 'secret to match hardcoded 'secret' @ http://jwt.io'
+  let(:verify)  { true }
+
+  let(:inner_app) do
+    ->(env) { [200, env, [payload.to_json]] }
+  end
+
+  let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret) }
+
+  describe 'work as expected with' do
+    let(:time) { Time.new(2014, 02, 06, 16, 12, 0, '-08:00') }
+
+    before do
+      allow(Time).to receive_message_chain(:now).and_return(time)
+    end
+
+    # behavior of this is changing after jwt v1.5.2 when you can specify a lambda for verify_jti
+    # right now its hard-coded to verify against an MD5
+    let(:jti_digest) { Digest::MD5.hexdigest([secret, Time.now.to_i].join(':').to_s) }
+
+    let(:payload) do
+      {
+        data: 'data',
+        exp: Time.now.to_i + 4 * 3600,
+        nbf: Time.now.to_i - 3600,
+        iss: 'https://my.awesome.website/',
+        aud: 'audience',
+        jti: jti_digest,
+        iat: Time.now.to_i,
+        sub: 'subject'
+      }
+    end
+
+    let(:decode_args) do
+      {
+        secret: secret,
+        verify: true,
+        options: {
+          algorithm: 'HS256',
+          verify_expiration: true,
+          verify_not_before: true,
+          iss: 'https://my.awesome.website/',
+          verify_iss: true,
+          verify_iat: true,
+          jti: jti_digest,
+          verify_jti: true,
+          aud: 'audience',
+          verify_aud: true,
+          sub: 'subject',
+          verify_sub: true,
+          leeway: 30
+        }
+      }
+    end
+
+    let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, decode_args) }
+
+    it 'valid sample code' do
+      header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS256')}"
+      get('/')
+      expect(last_response.status).to eq 200
+      body = JSON.parse(last_response.body, symbolize_names: true)
+      expect(body).to eq(payload)
+      expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"HS256"})
+    end
+  end
+end

--- a/spec/jwt/exception_spec.rb
+++ b/spec/jwt/exception_spec.rb
@@ -1,0 +1,121 @@
+describe Logicware::Rack::JWT::Auth do
+  let(:issuer)  { Logicware::Rack::JWT::Token }
+  let(:secret)  { 'secret' } # use 'secret to match hardcoded 'secret' @ http://jwt.io'
+  let(:verify)  { true }
+  let(:payload) { { foo: 'bar' } }
+
+  let(:inner_app) do
+    ->(env) { [200, env, [payload.to_json]] }
+  end
+
+  let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret) }
+
+  describe 'handles the exception' do
+    before(:each) do
+      header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS256')}"
+      get('/')
+    end
+
+    let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: 'secret') }
+
+    describe '::JWT::VerificationError' do
+      let(:inner_app) { ->(_env) { raise ::JWT::VerificationError } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token : Signature Verification Error')
+      end
+    end
+
+    describe '::JWT::ExpiredSignature' do
+      let(:inner_app) { ->(_env) { raise ::JWT::ExpiredSignature } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token : Expired Signature (exp)')
+      end
+    end
+
+    describe '::JWT::IncorrectAlgorithm' do
+      let(:inner_app) { ->(_env) { raise ::JWT::IncorrectAlgorithm } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token : Incorrect Key Algorithm')
+      end
+    end
+
+    describe '::JWT::ImmatureSignature' do
+      let(:inner_app) { ->(_env) { raise ::JWT::ImmatureSignature } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token : Immature Signature (nbf)')
+      end
+    end
+
+    describe '::JWT::InvalidIssuerError' do
+      let(:inner_app) { ->(_env) { raise ::JWT::InvalidIssuerError } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token : Invalid Issuer (iss)')
+      end
+    end
+
+    describe '::JWT::InvalidIatError' do
+      let(:inner_app) { ->(_env) { raise ::JWT::InvalidIatError } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token : Invalid Issued At (iat)')
+      end
+    end
+
+    describe '::JWT::InvalidAudError' do
+      let(:inner_app) { ->(_env) { raise ::JWT::InvalidAudError } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token : Invalid Audience (aud)')
+      end
+    end
+
+    describe '::JWT::InvalidSubError' do
+      let(:inner_app) { ->(_env) { raise ::JWT::InvalidSubError } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token : Invalid Subject (sub)')
+      end
+    end
+
+    describe '::JWT::InvalidJtiError' do
+      let(:inner_app) { ->(_env) { raise ::JWT::InvalidJtiError } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token : Invalid JWT ID (jti)')
+      end
+    end
+
+    describe '::JWT::DecodeError' do
+      let(:inner_app) { ->(_env) { raise ::JWT::DecodeError } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token : Decode Error')
+      end
+    end
+  end
+end

--- a/spec/jwt/exclusion_spec.rb
+++ b/spec/jwt/exclusion_spec.rb
@@ -1,0 +1,59 @@
+describe Logicware::Rack::JWT::Auth do
+  let(:issuer)  { Logicware::Rack::JWT::Token }
+  let(:secret)  { 'secret' } # use 'secret to match hardcoded 'secret' @ http://jwt.io'
+  let(:verify)  { true }
+  let(:payload) { { foo: 'bar' } }
+
+  let(:inner_app) do
+    ->(env) { [200, env, [payload.to_json]] }
+  end
+
+  let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret) }
+
+  describe 'when handling exlusions' do
+    describe 'passes through matching exact path' do
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, exclude: ['/static']) }
+
+      it 'returns a 200' do
+        get('/static')
+        expect(last_response.status).to eq 200
+      end
+    end
+
+    describe 'passes through matching exact path with trailing slash' do
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, exclude: ['/static']) }
+
+      it 'returns a 200' do
+        get('/static/')
+        expect(last_response.status).to eq 200
+      end
+    end
+
+    describe 'passes through matching exact path with sub-path' do
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, exclude: ['/static']) }
+
+      it 'returns a 200' do
+        get('/static/foo/bar')
+        expect(last_response.status).to eq 200
+      end
+    end
+
+    describe 'passes through matching path with multiple exclusions' do
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, exclude: %w(/docs /books /static)) }
+
+      it 'returns a 200' do
+        get('/static/foo/bar')
+        expect(last_response.status).to eq 200
+      end
+    end
+
+    describe 'fails when no matching path and no token' do
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, exclude: %w(/docs /books /static)) }
+
+      it 'returns a 200' do
+        get('/somewhere')
+        expect(last_response.status).to eq 401
+      end
+    end
+  end
+end

--- a/spec/jwt/on_error_spec.rb
+++ b/spec/jwt/on_error_spec.rb
@@ -1,0 +1,158 @@
+describe Logicware::Rack::JWT::Auth do
+  let(:issuer)  { Logicware::Rack::JWT::Token }
+  let(:secret)  { 'secret' } # use 'secret to match hardcoded 'secret' @ http://jwt.io'
+  let(:verify)  { true }
+  let(:payload) { { foo: 'bar' } }
+
+  let(:inner_app) do
+    ->(env) { [200, env, [payload.to_json]] }
+  end
+
+  let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret) }
+
+  describe 'handles the exception' do
+    before(:each) do
+      header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS256')}"
+      get('/')
+    end
+
+    let(:on_error) do
+      lambda do |error|
+        message =
+          if Logicware::Rack::JWT::Auth::JWT_DECODE_ERRORS.include?(error.class)
+            'Invalid JWT token'
+          elsif error.is_a?(Logicware::Rack::JWT::Auth::MissingAuthHeader)
+            'Missing Authorization header'
+          elsif error.is_a?(Logicware::Rack::JWT::Auth::InvalidAuthHeaderFormat)
+            'Invalid Authorization header format'
+          end
+        body    = { error: message }.to_json
+        headers = { 'Content-Type' => 'application/json', 'Content-Length' => body.bytesize.to_s }
+
+        [401, headers, [body]]
+      end
+    end
+
+    let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: 'secret', on_error: on_error) }
+
+    describe '::JWT::VerificationError' do
+      let(:inner_app) { ->(_env) { raise ::JWT::VerificationError } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token')
+      end
+    end
+
+    describe '::JWT::ExpiredSignature' do
+      let(:inner_app) { ->(_env) { raise ::JWT::ExpiredSignature } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token')
+      end
+    end
+
+    describe '::JWT::IncorrectAlgorithm' do
+      let(:inner_app) { ->(_env) { raise ::JWT::IncorrectAlgorithm } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token')
+      end
+    end
+
+    describe '::JWT::ImmatureSignature' do
+      let(:inner_app) { ->(_env) { raise ::JWT::ImmatureSignature } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token')
+      end
+    end
+
+    describe '::JWT::InvalidIssuerError' do
+      let(:inner_app) { ->(_env) { raise ::JWT::InvalidIssuerError } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token')
+      end
+    end
+
+    describe '::JWT::InvalidIatError' do
+      let(:inner_app) { ->(_env) { raise ::JWT::InvalidIatError } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token')
+      end
+    end
+
+    describe '::JWT::InvalidAudError' do
+      let(:inner_app) { ->(_env) { raise ::JWT::InvalidAudError } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token')
+      end
+    end
+
+    describe '::JWT::InvalidSubError' do
+      let(:inner_app) { ->(_env) { raise ::JWT::InvalidSubError } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token')
+      end
+    end
+
+    describe '::JWT::InvalidJtiError' do
+      let(:inner_app) { ->(_env) { raise ::JWT::InvalidJtiError } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token')
+      end
+    end
+
+    describe '::JWT::DecodeError' do
+      let(:inner_app) { ->(_env) { raise ::JWT::DecodeError } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token')
+      end
+    end
+
+    describe '::Rack::JWT::Auth::MissingAuthHeader' do
+      let(:inner_app) { ->(_env) { raise Logicware::Rack::JWT::Auth::MissingAuthHeader } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Missing Authorization header')
+      end
+    end
+
+    describe '::Rack::JWT::Auth::InvalidAuthHeaderFormat' do
+      let(:inner_app) { ->(_env) { raise Logicware::Rack::JWT::Auth::InvalidAuthHeaderFormat } }
+
+      it 'returns a 401 and the correct error msg' do
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid Authorization header format')
+      end
+    end
+  end
+end

--- a/spec/jwt/token_spec.rb
+++ b/spec/jwt/token_spec.rb
@@ -1,0 +1,345 @@
+describe Logicware::Rack::JWT::Auth do
+  let(:issuer)  { Logicware::Rack::JWT::Token }
+  let(:secret)  { 'secret' } # use 'secret to match hardcoded 'secret' @ http://jwt.io'
+  let(:verify)  { true }
+  let(:payload) { { foo: 'bar' } }
+
+  let(:inner_app) do
+    ->(env) { [200, env, [payload.to_json]] }
+  end
+
+  let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret) }
+
+  describe 'receiving valid Authorization headers' do
+    describe 'with unsigned (none) valid header and token' do
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: nil, verify: false, options: { algorithm: 'none' }) }
+
+      it 'returns a 200' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, nil, 'none')}"
+        get('/')
+        expect(last_response.status).to eq 200
+        expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"none"})
+        expect(last_response.headers['jwt.payload']).to eq("foo" => "bar")
+      end
+    end
+
+    describe 'with valid HMAC HS256 token (default)' do
+      it 'returns a 200' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS256')}"
+        get('/')
+        expect(last_response.status).to eq 200
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(payload)
+        expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"HS256"})
+        expect(last_response.headers['jwt.payload']).to eq("foo" => "bar")
+      end
+    end
+
+    describe 'with valid HMAC HS256 token (explicit)' do
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, verify: verify, options: { algorithm: 'HS256' }) }
+
+      it 'returns a 200' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS256')}"
+        get('/')
+        expect(last_response.status).to eq 200
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(payload)
+        expect(last_response.headers['jwt.header']).to eq({"typ" => "JWT", "alg" => "HS256"})
+        expect(last_response.headers['jwt.payload']).to eq({"foo" => "bar"})
+      end
+    end
+
+    describe 'with valid HMAC HS256 token from http://jwt.io' do
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, verify: verify, options: { algorithm: 'HS256' }) }
+
+      it 'returns a 200' do
+        # generate with HMAC secret of 'secret'
+        header 'Authorization', "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ"
+        get('/')
+        expect(last_response.status).to eq 200
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(payload)
+        expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"HS256"})
+        expect(last_response.headers['jwt.payload']).to eq({"sub"=>"1234567890", "name"=>"John Doe", "admin"=>true})
+      end
+    end
+
+    describe 'with valid HMAC HS384 token' do
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, verify: verify, options: { algorithm: 'HS384' }) }
+
+      it 'returns a 200' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS384')}"
+        get('/')
+        expect(last_response.status).to eq 200
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(payload)
+        expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"HS384"})
+        expect(last_response.headers['jwt.payload']).to eq("foo" => "bar")
+      end
+    end
+
+    describe 'with valid HMAC HS512 token' do
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, verify: verify, options: { algorithm: 'HS512' }) }
+
+      it 'returns a 200' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, secret, 'HS512')}"
+        get('/')
+        expect(last_response.status).to eq 200
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(payload)
+        expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"HS512"})
+        expect(last_response.headers['jwt.payload']).to eq("foo" => "bar")
+      end
+    end
+
+    describe 'with valid RSA RS256 key token' do
+      let(:rsa_private) { OpenSSL::PKey::RSA.generate(2048) }
+      let(:rsa_public)  { rsa_private.public_key }
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: rsa_public, verify: verify, options: { algorithm: 'RS256' }) }
+
+      it 'returns a 200' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, rsa_private, 'RS256')}"
+        get('/')
+        expect(last_response.status).to eq 200
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(payload)
+        expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"RS256"})
+        expect(last_response.headers['jwt.payload']).to eq("foo" => "bar")
+      end
+    end
+
+    describe 'with valid RSA RS384 key token' do
+      let(:rsa_private) { OpenSSL::PKey::RSA.generate(2048) }
+      let(:rsa_public)  { rsa_private.public_key }
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: rsa_public, verify: verify, options: { algorithm: 'RS384' }) }
+
+      it 'returns a 200' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, rsa_private, 'RS384')}"
+        get('/')
+        expect(last_response.status).to eq 200
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(payload)
+        expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"RS384"})
+        expect(last_response.headers['jwt.payload']).to eq("foo" => "bar")
+      end
+    end
+
+    describe 'with valid RSA RS512 key token' do
+      let(:rsa_private) { OpenSSL::PKey::RSA.generate(2048) }
+      let(:rsa_public)  { rsa_private.public_key }
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: rsa_public, verify: verify, options: { algorithm: 'RS512' }) }
+
+      it 'returns a 200' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, rsa_private, 'RS512')}"
+        get('/')
+        expect(last_response.status).to eq 200
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(payload)
+        expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"RS512"})
+        expect(last_response.headers['jwt.payload']).to eq("foo" => "bar")
+      end
+    end
+
+    describe 'with valid EC ES256 key token' do
+      ecdsa = OpenSSL::PKey::EC.new('prime256v1')
+      ecdsa.generate_key
+      let(:ecdsa) { ecdsa }
+      ecdsa_pub = OpenSSL::PKey::EC.new(ecdsa)
+      ecdsa_pub.private_key = nil
+      let(:ecdsa_pub) { ecdsa_pub }
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: ecdsa_pub, verify: verify, options: { algorithm: 'ES256' }) }
+
+      it 'returns a 200' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, ecdsa, 'ES256')}"
+        get('/')
+        expect(last_response.status).to eq 200
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(payload)
+        expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"ES256"})
+        expect(last_response.headers['jwt.payload']).to eq("foo" => "bar")
+      end
+    end
+
+    describe 'with valid EC ES384 key token' do
+      ecdsa = OpenSSL::PKey::EC.new('secp384r1')
+      ecdsa.generate_key
+      let(:ecdsa) { ecdsa }
+      ecdsa_pub = OpenSSL::PKey::EC.new(ecdsa)
+      ecdsa_pub.private_key = nil
+      let(:ecdsa_pub) { ecdsa_pub }
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: ecdsa_pub, verify: verify, options: { algorithm: 'ES384' }) }
+
+      it 'returns a 200' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, ecdsa, 'ES384')}"
+        get('/')
+        expect(last_response.status).to eq 200
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(payload)
+        expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"ES384"})
+        expect(last_response.headers['jwt.payload']).to eq("foo" => "bar")
+      end
+    end
+
+    describe 'with valid EC ES512 key token' do
+      ecdsa = OpenSSL::PKey::EC.new('secp521r1')
+      ecdsa.generate_key
+      let(:ecdsa) { ecdsa }
+      ecdsa_pub = OpenSSL::PKey::EC.new(ecdsa)
+      ecdsa_pub.private_key = nil
+      let(:ecdsa_pub) { ecdsa_pub }
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: ecdsa_pub, verify: verify, options: { algorithm: 'ES512' }) }
+
+      it 'returns a 200' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, ecdsa, 'ES512')}"
+        get('/')
+        expect(last_response.status).to eq 200
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(payload)
+        expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"ES512"})
+        expect(last_response.headers['jwt.payload']).to eq("foo" => "bar")
+      end
+    end
+
+    describe 'with valid ED25519 key token' do
+      private_key = RbNaCl::Signatures::Ed25519::SigningKey.generate
+      public_key  = private_key.verify_key
+
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: public_key, verify: verify, options: { algorithm: 'ED25519' }) }
+
+      it 'returns a 200' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, private_key, 'ED25519')}"
+        get('/')
+        expect(last_response.status).to eq 200
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(payload)
+        expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"ED25519"})
+        expect(last_response.headers['jwt.payload']).to eq("foo" => "bar")
+      end
+    end
+  end
+
+  describe 'receiving invalid Authorization headers' do
+
+    # skip all verification!!!
+    describe 'succeeds when verify: false even though secret in token is bad' do
+      let(:app) { Logicware::Rack::JWT::Auth.new(inner_app, secret: secret, verify: false) }
+
+      it 'returns a 200' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, 'badsecret', 'HS256')}"
+        get('/')
+        expect(last_response.status).to eq 200
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(payload)
+        expect(last_response.headers['jwt.header']).to eq({"typ"=>"JWT", "alg"=>"HS256"})
+        expect(last_response.headers['jwt.payload']).to eq("foo" => "bar")
+      end
+    end
+
+    describe 'with missing header' do
+      it 'returns a 401' do
+        get('/')
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Missing Authorization header')
+        expect(last_response.headers['jwt.header']).to eq(nil)
+        expect(last_response.headers['jwt.payload']).to eq(nil)
+      end
+    end
+
+    describe 'with header, schema, but empty token' do
+      it 'returns a 401' do
+        header 'Authorization', 'Bearer '
+        get('/')
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid Authorization header format')
+        expect(last_response.headers['jwt.header']).to eq(nil)
+        expect(last_response.headers['jwt.payload']).to eq(nil)
+      end
+    end
+
+    describe 'with header and token but missing schema' do
+      it 'returns a 401' do
+        header 'Authorization', issuer.encode(payload, secret, 'HS256')
+        get('/')
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid Authorization header format')
+        expect(last_response.headers['jwt.header']).to eq(nil)
+        expect(last_response.headers['jwt.payload']).to eq(nil)
+      end
+    end
+
+    describe 'with header and valid token but incorrect schema' do
+      it 'returns a 401' do
+        header 'Authorization', "Badstuff #{issuer.encode(payload, secret, 'HS256')}"
+        get('/')
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid Authorization header format')
+        expect(last_response.headers['jwt.header']).to eq(nil)
+        expect(last_response.headers['jwt.payload']).to eq(nil)
+      end
+    end
+
+    describe 'with header and malformed double period token' do
+      it 'returns a 401' do
+        header 'Authorization', 'Bearer abc123..abc123.abc123'
+        get('/')
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid Authorization header format')
+        expect(last_response.headers['jwt.header']).to eq(nil)
+        expect(last_response.headers['jwt.payload']).to eq(nil)
+      end
+    end
+
+    describe 'with header and malformed trailing period token' do
+      it 'returns a 401' do
+        header 'Authorization', 'Bearer abc123.abc123.abc123.'
+        get('/')
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid Authorization header format')
+        expect(last_response.headers['jwt.header']).to eq(nil)
+        expect(last_response.headers['jwt.payload']).to eq(nil)
+      end
+    end
+
+    describe 'with header and malformed leading period token' do
+      it 'returns a 401' do
+        header 'Authorization', 'Bearer .abc123.abc123.abc123'
+        get('/')
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid Authorization header format')
+        expect(last_response.headers['jwt.header']).to eq(nil)
+        expect(last_response.headers['jwt.payload']).to eq(nil)
+      end
+    end
+
+    describe 'with header and malformed bad character token' do
+      it 'returns a 401' do
+        header 'Authorization', 'Bearer abc!123.abc123.abc123'
+        get('/')
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid Authorization header format')
+        expect(last_response.headers['jwt.header']).to eq(nil)
+        expect(last_response.headers['jwt.payload']).to eq(nil)
+      end
+    end
+
+    describe 'with header and valid token but a different secret in the token than on server' do
+      it 'returns a 401' do
+        header 'Authorization', "Bearer #{issuer.encode(payload, 'badsecret', 'HS256')}"
+        get('/')
+        expect(last_response.status).to eq 401
+        body = JSON.parse(last_response.body, symbolize_names: true)
+        expect(body).to eq(error: 'Invalid JWT token : Signature Verification Error')
+        expect(last_response.headers['jwt.header']).to eq(nil)
+        expect(last_response.headers['jwt.payload']).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/logicware_spec.rb
+++ b/spec/logicware_spec.rb
@@ -2,8 +2,4 @@ RSpec.describe Logicware do
   it "has a version number" do
     expect(Logicware::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,14 @@
 require "bundler/setup"
 require "logicware"
+require "logicware/rack/jwt"
+require "rack/test"
 
 RSpec.configure do |config|
+  # Include Rack::Test::Methods
+  config.include Rack::Test::Methods
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
-
-  # Disable RSpec exposing methods globally on `Module` and `main`
-  config.disable_monkey_patching!
 
   config.expect_with :rspec do |c|
     c.syntax = :expect


### PR DESCRIPTION
Finished in 0.36839 seconds (files took 0.65375 seconds to load)
75 examples, 0 failures

example_id                             | status | run_time        |
-------------------------------------- | ------ | --------------- |
./spec/jwt/auth_spec.rb[1:1:1:1:1]     | passed | 0.00161 seconds |
./spec/jwt/auth_spec.rb[1:1:1:2:1]     | passed | 0.00177 seconds |
./spec/jwt/auth_spec.rb[1:1:1:3:1]     | passed | 0.00017 seconds |
./spec/jwt/auth_spec.rb[1:1:1:4:1]     | passed | 0.00011 seconds |
./spec/jwt/auth_spec.rb[1:1:1:5:1]     | passed | 0.00011 seconds |
./spec/jwt/auth_spec.rb[1:1:1:6:1]     | passed | 0.0001 seconds  |
./spec/jwt/auth_spec.rb[1:1:2:1:1]     | passed | 0.01196 seconds |
./spec/jwt/auth_spec.rb[1:1:2:2:1]     | passed | 0.00063 seconds |
./spec/jwt/auth_spec.rb[1:1:2:3:1]     | passed | 0.00017 seconds |
./spec/jwt/auth_spec.rb[1:1:3:1:1]     | passed | 0.00069 seconds |
./spec/jwt/auth_spec.rb[1:1:3:2:1]     | passed | 0.00015 seconds |
./spec/jwt/auth_spec.rb[1:1:3:3:1]     | passed | 0.00012 seconds |
./spec/jwt/auth_spec.rb[1:1:3:4:1]     | passed | 0.00011 seconds |
./spec/jwt/auth_spec.rb[1:1:4:1:1]     | passed | 0.00014 seconds |
./spec/jwt/auth_spec.rb[1:1:4:2:1]     | passed | 0.00013 seconds |
./spec/jwt/auth_spec.rb[1:1:4:3:1]     | passed | 0.00011 seconds |
./spec/jwt/auth_spec.rb[1:1:4:4:1]     | passed | 0.00012 seconds |
./spec/jwt/auth_spec.rb[1:1:5:1:1]     | passed | 0.00012 seconds |
./spec/jwt/claims_spec.rb[1:1:1:1:1:1] | passed | 0.00073 seconds |
./spec/jwt/claims_spec.rb[1:1:1:1:2:1] | passed | 0.00056 seconds |
./spec/jwt/claims_spec.rb[1:1:1:1:3:1] | passed | 0.00059 seconds |
./spec/jwt/claims_spec.rb[1:1:1:1:4:1] | passed | 0.00066 seconds |
./spec/jwt/claims_spec.rb[1:1:1:2:1:1] | passed | 0.00095 seconds |
./spec/jwt/example_spec.rb[1:1:1]      | passed | 0.00442 seconds |
./spec/jwt/exception_spec.rb[1:1:1:1]  | passed | 0.00072 seconds |
./spec/jwt/exception_spec.rb[1:1:2:1]  | passed | 0.0007 seconds  |
./spec/jwt/exception_spec.rb[1:1:3:1]  | passed | 0.00054 seconds |
./spec/jwt/exception_spec.rb[1:1:4:1]  | passed | 0.00065 seconds |
./spec/jwt/exception_spec.rb[1:1:5:1]  | passed | 0.0006 seconds  |
./spec/jwt/exception_spec.rb[1:1:6:1]  | passed | 0.00062 seconds |
./spec/jwt/exception_spec.rb[1:1:7:1]  | passed | 0.00054 seconds |
./spec/jwt/exception_spec.rb[1:1:8:1]  | passed | 0.00057 seconds |
./spec/jwt/exception_spec.rb[1:1:9:1]  | passed | 0.00057 seconds |
./spec/jwt/exception_spec.rb[1:1:10:1] | passed | 0.00052 seconds |
./spec/jwt/exclusion_spec.rb[1:1:1:1]  | passed | 0.00041 seconds |
./spec/jwt/exclusion_spec.rb[1:1:2:1]  | passed | 0.00046 seconds |
./spec/jwt/exclusion_spec.rb[1:1:3:1]  | passed | 0.00047 seconds |
./spec/jwt/exclusion_spec.rb[1:1:4:1]  | passed | 0.00039 seconds |
./spec/jwt/exclusion_spec.rb[1:1:5:1]  | passed | 0.00038 seconds |
./spec/jwt/on_error_spec.rb[1:1:1:1]   | passed | 0.00085 seconds |
./spec/jwt/on_error_spec.rb[1:1:2:1]   | passed | 0.00069 seconds |
./spec/jwt/on_error_spec.rb[1:1:3:1]   | passed | 0.00085 seconds |
./spec/jwt/on_error_spec.rb[1:1:4:1]   | passed | 0.00131 seconds |
./spec/jwt/on_error_spec.rb[1:1:5:1]   | passed | 0.00074 seconds |
./spec/jwt/on_error_spec.rb[1:1:6:1]   | passed | 0.00072 seconds |
./spec/jwt/on_error_spec.rb[1:1:7:1]   | passed | 0.00083 seconds |
./spec/jwt/on_error_spec.rb[1:1:8:1]   | passed | 0.00069 seconds |
./spec/jwt/on_error_spec.rb[1:1:9:1]   | passed | 0.00063 seconds |
./spec/jwt/on_error_spec.rb[1:1:10:1]  | passed | 0.00058 seconds |
./spec/jwt/on_error_spec.rb[1:1:11:1]  | passed | 0.00055 seconds |
./spec/jwt/on_error_spec.rb[1:1:12:1]  | passed | 0.00062 seconds |
./spec/jwt/token_spec.rb[1:1:1:1]      | passed | 0.00048 seconds |
./spec/jwt/token_spec.rb[1:1:2:1]      | passed | 0.00067 seconds |
./spec/jwt/token_spec.rb[1:1:3:1]      | passed | 0.00252 seconds |
./spec/jwt/token_spec.rb[1:1:4:1]      | passed | 0.00082 seconds |
./spec/jwt/token_spec.rb[1:1:5:1]      | passed | 0.00067 seconds |
./spec/jwt/token_spec.rb[1:1:6:1]      | passed | 0.00059 seconds |
./spec/jwt/token_spec.rb[1:1:7:1]      | passed | 0.07592 seconds |
./spec/jwt/token_spec.rb[1:1:8:1]      | passed | 0.09763 seconds |
./spec/jwt/token_spec.rb[1:1:9:1]      | passed | 0.10763 seconds |
./spec/jwt/token_spec.rb[1:1:10:1]     | passed | 0.00085 seconds |
./spec/jwt/token_spec.rb[1:1:11:1]     | passed | 0.00298 seconds |
./spec/jwt/token_spec.rb[1:1:12:1]     | passed | 0.00154 seconds |
./spec/jwt/token_spec.rb[1:1:13:1]     | passed | 0.00065 seconds |
./spec/jwt/token_spec.rb[1:2:1:1]      | passed | 0.00045 seconds |
./spec/jwt/token_spec.rb[1:2:2:1]      | passed | 0.00028 seconds |
./spec/jwt/token_spec.rb[1:2:3:1]      | passed | 0.00028 seconds |
./spec/jwt/token_spec.rb[1:2:4:1]      | passed | 0.00048 seconds |
./spec/jwt/token_spec.rb[1:2:5:1]      | passed | 0.00052 seconds |
./spec/jwt/token_spec.rb[1:2:6:1]      | passed | 0.00032 seconds |
./spec/jwt/token_spec.rb[1:2:7:1]      | passed | 0.00028 seconds |
./spec/jwt/token_spec.rb[1:2:8:1]      | passed | 0.00028 seconds |
./spec/jwt/token_spec.rb[1:2:9:1]      | passed | 0.00028 seconds |
./spec/jwt/token_spec.rb[1:2:10:1]     | passed | 0.00056 seconds |
./spec/logicware_spec.rb[1:1]          | passed | 0.00096 seconds |
